### PR TITLE
Isbn search

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,19 @@ Requires Calibre 0.8 or later. Tested with 3.2.0.0
 Download the attached zip file and install the plugin as described in the Introduction to plugins thread.
 Note that this is not a GUI plugin so it is not intended/cannot be added to context menus/toolbars etc.
 
+
 ## Version History:
+
+**Version 1.0.8** - 30 May 2018
+Search primarily by isbn. (It's the most specific and accurate data. Try out the Extract ISBN plugin. With that the search is almost flawles)
+If no match found fall back to broader search.
+If no match try to remove () parts from title, after that try to remove authors.
+Update by Dezso
+
+**Version 1.0.7** -  8 May 2018
+Find switched family-first names as well 
+Update by otapi
+
 **Version 1.0.6** - 11 April 2018
 The filter of relevant title and author by transliterate the extended Hungarian characters
 Update by otapi

--- a/__init__.py
+++ b/__init__.py
@@ -120,12 +120,21 @@ class Moly_hu(Source):
 			return
 
 		if not matches:
+			log.error('No matches found with query: %r'%query)
 			if identifiers and title and authors:
 				log.info('No matches found with identifiers, retrying using only'
 						' title and authors')
 				return self.identify(log, result_queue, abort, title=title,
-						authors=authors, timeout=timeout)
-			log.error('No matches found with query: %r'%query)
+						authors=authors, timeout=timeout)		
+			elif title and authors and title!=title.split("(")[0]:
+				log.info('No matches found with authors and title try removing () part from title, and search by title and author')
+				tit=title.split("(")[0]
+				return self.identify(log, result_queue, abort, title=tit,
+						authors=authors, timeout=timeout)	
+			elif title and authors:
+				log.info('No matches found with authors and title, retrying using only title')
+				return self.identify(log, result_queue, abort, title=title,
+						authors=None, timeout=timeout)
 			return
 
 		from calibre_plugins.moly_hu.worker import Worker

--- a/__init__.py
+++ b/__init__.py
@@ -187,6 +187,16 @@ class Moly_hu(Source):
 					i += 1
 				if (i >= max_results):
 					return
+		if i==0:
+			for result in results:
+				book_urls = result.xpath('@href')
+				for book_url in book_urls:
+					result_url = Moly_hu.BASE_URL + book_url
+					if (result_url not in matches):
+						matches.append(result_url)
+						i += 1
+					if (i >= max_results):
+						return
 		
 	def strip_accents(self, s):
 		symbols = (u"öÖüÜóÓőŐúÚéÉáÁűŰíÍ",

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 						print_function)
 
 __license__   = 'GPL v3'
-__copyright__ = '2011-2018, Hoffer Csaba <csaba.hoffer@gmail.com>, Kloon <kloon@techgeek.co.in>, otapi <otapigems.com>'
+__copyright__ = '2011-2018, Hoffer Csaba <csaba.hoffer@gmail.com>, Kloon <kloon@techgeek.co.in>, otapi <otapigems.com>, Dezso <orai.dezso@gmail.com>'
 __docformat__ = 'restructuredtext hu'
 
 import time
@@ -22,8 +22,8 @@ from calibre import browser
 class Moly_hu(Source):
 	name					= 'Moly_hu'
 	description				= _('Downloads metadata and covers from moly.hu')
-	author					= 'Hoffer Csaba & Kloon & fatsadt & otapi'
-	version					= (1, 0, 7)
+	author					= 'Hoffer Csaba & Kloon & fatsadt & otapi & Dezso'
+	version					= (1, 0, 8)
 	minimum_calibre_version = (0, 8, 0)
 
 	capabilities = frozenset(['identify', 'cover'])
@@ -46,6 +46,10 @@ class Moly_hu(Source):
 	SEARCH_URL = BASE_URL + '/kereses?utf8=%E2%9C%93&q='
 
 	def create_query(self, log, title=None, authors=None, identifiers={}):
+		isbn = check_isbn(identifiers.get('isbn', None))
+		if isbn is not None:
+			return (Moly_hu.SEARCH_URL + '%s'%(isbn).encode('utf-8'))
+			
 		if title is not None:
 			search_title = urllib.quote(title.encode('utf-8'))
 		else:
@@ -109,7 +113,8 @@ class Moly_hu(Source):
 				msg = 'Failed to parse moly.hu page for query: %r'%query
 				log.exception(msg)
 				return msg
-			self._parse_search_results(log, title, authors, root, matches, timeout)
+			isbn=check_isbn(identifiers.get('isbn', None))
+			self._parse_search_results(log, title, authors, root, matches, timeout, isbn)
 
 		if abort.is_set():
 			return
@@ -144,31 +149,35 @@ class Moly_hu(Source):
 				break
 
 		return None
-	def _parse_search_results(self, log, orig_title, orig_authors, root, matches, timeout):
+		
+
+	def _parse_search_results(self, log, orig_title, orig_authors, root, matches, timeout, isbn):
 		max_results = self.prefs[Moly_hu.KEY_MAX_BOOKS]
 		results = root.xpath('//a[@class="book_selector"]')
 		log.info('Found %d possible books (max: %d)'%(len(results), max_results))
 		i = 0
 		for result in results:
 			book_urls = result.xpath('@href')
-			etree.strip_tags(result, 'strong')
-			author_n_title = result.text
-			author_n_titles = author_n_title.split(':', 1)
-			author = author_n_titles[0].strip(' \r\n\t')
-			title = author_n_titles[1].strip(' \r\n\t')
-			log.info('Orig: %s, target: %s'%(self.strip_accents(orig_title), self.strip_accents(title)))
 			
-			if orig_title:
-				if orig_title.lower() not in title.lower() and self.strip_accents(orig_title) not in self.strip_accents(title):
-					continue
-			if orig_authors:
-				author1 = orig_authors[0]
-				authorsplit = author1.split(" ")
-				author2 = author1
-				if len(authorsplit) > 1:
-					author2 = '%s %s'%(authorsplit[1], authorsplit[0])
-				if author1.lower() not in author.lower() and self.strip_accents(author1) not in self.strip_accents(author) and author2.lower() not in author.lower() and self.strip_accents(author2) not in self.strip_accents(author):
-					continue
+			if isbn is None:
+				etree.strip_tags(result, 'strong')
+				author_n_title = result.text
+				author_n_titles = author_n_title.split(':', 1)
+				author = author_n_titles[0].strip(' \r\n\t')
+				title = author_n_titles[1].strip(' \r\n\t')
+				log.info('Orig: %s, target: %s'%(self.strip_accents(orig_title), self.strip_accents(title)))
+			
+				if orig_title:
+					if orig_title.lower() not in title.lower() and self.strip_accents(orig_title) not in self.strip_accents(title):
+						continue
+				if orig_authors:
+					author1 = orig_authors[0]
+					authorsplit = author1.split(" ")
+					author2 = author1
+					if len(authorsplit) > 1:
+						author2 = '%s %s'%(authorsplit[1], authorsplit[0])
+					if author1.lower() not in author.lower() and self.strip_accents(author1) not in self.strip_accents(author) and author2.lower() not in author.lower() and self.strip_accents(author2) not in self.strip_accents(author):
+						continue
 			
 			for book_url in book_urls:
 				result_url = Moly_hu.BASE_URL + book_url

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+[B]Version 1.0.8[/B] - 30 May 2018
+Search primarily by isbn. (It's the most specific and accurate data. Try out the Extract ISBN plugin. With that the search is almost flawles)
+If no match found fall back to broader search.
+If no match try to remove () parts from title, after that try to remove authors.
+Update by Dezso
+
 [B]Version 1.0.7[/B] - 8 May 2018
 Find switched family-first names as well 
 Update by otapi


### PR DESCRIPTION
Hello.

I added search by isbn number, witch is really useful, because it's the most accurate data of the book. And there are existing plugins for searching isbn in a book. By this two you can search and download metadata in great magnitudes with accuracy.

Also there was some cases, when the title is correct, but the author isn't, or there was the name of the series inside "()" in the title, and the plugin won't find it. So I added some fallback for that. Of course only if there was no match. These matches are not as well, as the others, but at least it finds them.